### PR TITLE
fix(run-script): silent run-script on log.level=silent

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,10 @@ async function pack (spec = 'file:.', opts = {}) {
 
   const manifest = await pacote.manifest(spec, opts)
 
+  // Default to true if no log options passed, set to false if we're in silent
+  // mode
+  const banner = !opts.log || (opts.log.level !== 'silent')
+
   if (spec.type === 'directory') {
     // prepack
     await runScript({
@@ -18,7 +22,8 @@ async function pack (spec = 'file:.', opts = {}) {
       event: 'prepack',
       path: spec.fetchSpec,
       stdio: 'inherit',
-      pkg: manifest
+      pkg: manifest,
+      banner
     })
   }
 
@@ -36,6 +41,7 @@ async function pack (spec = 'file:.', opts = {}) {
       path: spec.fetchSpec,
       stdio: 'inherit',
       pkg: manifest,
+      banner,
       env: {
         npm_package_from: tarball.from,
         npm_package_resolved: tarball.resolved,

--- a/test/index.js
+++ b/test/index.js
@@ -29,6 +29,25 @@ t.test('packs from local directory', async t => {
   })
 })
 
+t.test('packs from local directory with silent loglevel', async t => {
+  const testDir = t.testdir({
+    'package.json': JSON.stringify({
+      name: 'my-cool-pkg',
+      version: '1.0.0'
+    }, null, 2)
+  })
+
+  const cwd = process.cwd()
+  process.chdir(testDir)
+
+  const tarball = await pack('file:', { log: { level: 'silent' } })
+  t.ok(tarball)
+
+  t.teardown(async () => {
+    process.chdir(cwd)
+  })
+})
+
 t.test('packs from registry spec', async t => {
   const spec = 'my-cool-pkg'
   const packument = {


### PR DESCRIPTION
If log.level is silent we want to pass that intent on through
to run-script do that the output is suppressed