### PR TITLE
fix: pass the scope option to pacote for auth purposes

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ async function pack (spec = 'file:.', opts = {}) {
   // packs tarball
   const tarball = await pacote.tarball(manifest._resolved, {
     ...opts,
+    scope: spec.scope, // this is necessary to correctly identify auth later
     integrity: manifest._integrity
   })
 

--- a/test/fixtures/tnock.js
+++ b/test/fixtures/tnock.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const nock = require('nock')
+nock.disableNetConnect()
 
 module.exports = tnock
 function tnock (t, host) {


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
without the scope, the tarball url is passed through `npm-package-arg` which is expected to be able to identify a scope. since the url does not follow the standard npm registry url patterns, the scope is _not_ identified and so we do not apply the correct registry-specific auth header.

this change makes it so the scope from the original package identifier is passed through to pacote, ensuring that the correct registry and auth header are identified.

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
Fixes https://github.com/npm/cli/issues/2918